### PR TITLE
Add modern delegation calendar

### DIFF
--- a/projekt-delegacje/src/api/client.ts
+++ b/projekt-delegacje/src/api/client.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import type { Delegacja, LoginRequest, LoginResponse } from './types';
+import type { Delegacja, DelegacjaCreate, LoginRequest, LoginResponse } from './types';
 
 // Bazowy klient HTTP dla całej aplikacji
 export const api = axios.create({
@@ -21,4 +21,9 @@ export const login = async (
 export const getDelegacje = async (): Promise<Delegacja[]> => {
   const { data } = await api.get<Delegacja[]>('/api/Delegacje');
   return data;
+};
+
+// dodanie nowej delegacji
+export const createDelegacja = async (payload: DelegacjaCreate): Promise<void> => {
+  await api.post('/api/Delegacje', payload);
 };

--- a/projekt-delegacje/src/api/types.ts
+++ b/projekt-delegacje/src/api/types.ts
@@ -23,3 +23,15 @@ export interface Delegacja {
   uwagi?: string;
   timestamp?: string | null;
 }
+
+export interface DelegacjaCreate {
+  partitionKey: string;
+  rowKey: string;
+  pracownikImie: string;
+  pracownikNazwisko: string;
+  miejsce: string;
+  pracownikID: number;
+  dataRozpoczecia: string;
+  dataZakonczenia: string;
+  uwagi?: string;
+}

--- a/projekt-delegacje/src/pages/Dashboard.tsx
+++ b/projekt-delegacje/src/pages/Dashboard.tsx
@@ -1,12 +1,103 @@
 import '/src/styles/App.css';
 import '/src/styles/Dashboard.css';
+import { addMonths, eachDayOfInterval, endOfMonth, endOfWeek, format, isSameDay, isSameMonth, isWithinInterval, startOfMonth, startOfWeek } from 'date-fns';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useDelegacje } from '../api/hooks';
-import { useState } from 'react';
-import logo from '/src/img/logoArtikon.png'
+import { createDelegacja } from '../api/client';
+import { useMemo, useState } from 'react';
+import type { DelegacjaCreate } from '../api/types';
+import logo from '/src/img/logoArtikon.png';
 
 export const Dashboard = () => {
-    const { isLoading, isError } = useDelegacje();
+    const { data: delegacje = [], isLoading, isError } = useDelegacje();
+    const queryClient = useQueryClient();
     const [menuOpen, setMenuOpen] = useState(false);
+    const [currentMonth, setCurrentMonth] = useState(new Date());
+    const [selectedRange, setSelectedRange] = useState<{ start: Date | null; end: Date | null }>({
+        start: null,
+        end: null,
+    });
+    const [formState, setFormState] = useState({
+        pracownikImie: '',
+        pracownikNazwisko: '',
+        pracownikID: '',
+        miejsce: '',
+        uwagi: '',
+    });
+    const [submitMessage, setSubmitMessage] = useState<string | null>(null);
+
+    const mutation = useMutation({
+        mutationFn: async (payload: DelegacjaCreate) => createDelegacja(payload),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['delegacje'] });
+            setSubmitMessage('Delegacja została dodana do kalendarza.');
+            setSelectedRange({ start: null, end: null });
+            setFormState({ pracownikImie: '', pracownikNazwisko: '', pracownikID: '', miejsce: '', uwagi: '' });
+        },
+        onError: () => setSubmitMessage('Nie udało się zapisać delegacji. Sprawdź dane i spróbuj ponownie.'),
+    });
+
+    const monthDays = useMemo(() => {
+        const monthStart = startOfMonth(currentMonth);
+        const monthEnd = endOfMonth(monthStart);
+        const calendarStart = startOfWeek(monthStart, { weekStartsOn: 1 });
+        const calendarEnd = endOfWeek(monthEnd, { weekStartsOn: 1 });
+        return eachDayOfInterval({ start: calendarStart, end: calendarEnd });
+    }, [currentMonth]);
+
+    const delegationsByDay = useMemo(() =>
+        monthDays.map((day) => {
+            const matches = delegacje.filter((delegacja) =>
+                isWithinInterval(day, {
+                    start: new Date(delegacja.dataRozpoczecia),
+                    end: new Date(delegacja.dataZakonczenia),
+                }),
+            );
+            return { day, matches };
+        }),
+    [delegacje, monthDays]);
+
+    const handleDaySelection = (day: Date) => {
+        setSubmitMessage(null);
+        if (!selectedRange.start || (selectedRange.start && selectedRange.end)) {
+            setSelectedRange({ start: day, end: null });
+        } else if (selectedRange.start && !selectedRange.end) {
+            if (day < selectedRange.start) {
+                setSelectedRange({ start: day, end: selectedRange.start });
+            } else {
+                setSelectedRange({ start: selectedRange.start, end: day });
+            }
+        }
+    };
+
+    const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        setSubmitMessage(null);
+
+        if (!selectedRange.start || !selectedRange.end) {
+            setSubmitMessage('Wybierz zakres dat delegacji.');
+            return;
+        }
+
+        const payload: DelegacjaCreate = {
+            partitionKey: 'delegacja',
+            rowKey: '',
+            pracownikImie: formState.pracownikImie,
+            pracownikNazwisko: formState.pracownikNazwisko,
+            pracownikID: Number(formState.pracownikID),
+            miejsce: formState.miejsce,
+            dataRozpoczecia: selectedRange.start.toISOString(),
+            dataZakonczenia: selectedRange.end.toISOString(),
+            uwagi: formState.uwagi,
+        };
+
+        mutation.mutate(payload);
+    };
+
+    const handleInputChange = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+        const { name, value } = event.target;
+        setFormState((prev) => ({ ...prev, [name]: value }));
+    };
 
     if (isLoading) {
         return <p>Ładowanie delegacji...</p>;
@@ -17,33 +108,253 @@ export const Dashboard = () => {
     }
 
     return (
-        <header className="dark-header">
-            <div className="nav-center">
-                <div className="logo">
-                    <img src={logo} alt="Logo Artikon" loading="lazy" />
+        <div className="dashboard-wrapper">
+            <header className="dark-header">
+                <div className="nav-center">
+                    <div className="logo">
+                        <img src={logo} alt="Logo Artikon" loading="lazy" />
+                    </div>
+
+                    <button
+                        className="menu-toggle"
+                        aria-label="Przełącz menu"
+                        onClick={() => setMenuOpen(!menuOpen)}
+                    >
+                        ☰
+                    </button>
+
+                    <nav
+                        className={`main-nav ${menuOpen ? 'open' : ''}`}
+                        role="navigation"
+                        aria-label="Menu główne"
+                    >
+                        <a href="#kalendarz">Kalendarz</a>
+                        <a href="#raporty">Raporty</a>
+                        <a href="#delegacje">Delegacje</a>
+                        <a href="#ustawienia">Ustawienia</a>
+                    </nav>
                 </div>
+            </header>
 
-                <button
-                    className="menu-toggle"
-                    aria-label="Przełącz menu"
-                    onClick={() => setMenuOpen(!menuOpen)}
-                >
-                    ☰
-                </button>
+            <main className="dashboard-main">
+                <section className="hero-card">
+                    <div>
+                        <p className="eyebrow">Panel delegacji</p>
+                        <h1>Planowanie w trybie supershift</h1>
+                        <p className="subtitle">
+                            Zaznacz na kalendarzu daty delegacji, uzupełnij szczegóły i wyślij do systemu backendowego.
+                        </p>
+                        <div className="hero-actions">
+                            <button className="primary" onClick={() => document.getElementById('kalendarz')?.scrollIntoView({ behavior: 'smooth' })}>
+                                Dodaj delegację
+                            </button>
+                            <button className="ghost" onClick={() => setCurrentMonth(new Date())}>Dzisiejszy miesiąc</button>
+                        </div>
+                    </div>
+                    <div className="hero-meta">
+                        <p className="metric-label">Aktywne delegacje</p>
+                        <p className="metric-value">{delegacje.length}</p>
+                        <p className="metric-caption">Pobrane bezpośrednio z backendu C#</p>
+                    </div>
+                </section>
 
-                <nav
-                    className={`main-nav ${menuOpen ? 'open' : ''}`}
-                    role="navigation"
-                    aria-label="Menu główne"
-                >
-                    <a href="#glowna">Kalendarz</a>
-                    <a href="#raporty">Raporty</a>
-                    <a href="#delegacje">Delegacje</a>
-                    <a href="#ustawienia">Ustawienia</a>
-                </nav>
-            </div>
-        </header>
-        
+                <section className="calendar-section" id="kalendarz">
+                    <div className="calendar-header">
+                        <div>
+                            <p className="eyebrow">Kalendarz delegacji</p>
+                            <h2>{format(currentMonth, 'LLLL yyyy')}</h2>
+                            <p className="subtitle">Dotknij zakres dat, aby dodać delegację. Dni z kropką zawierają wpisy.</p>
+                        </div>
+                        <div className="month-nav">
+                            <button onClick={() => setCurrentMonth((prev) => addMonths(prev, -1))} aria-label="Poprzedni miesiąc">
+                                ◀
+                            </button>
+                            <button onClick={() => setCurrentMonth((prev) => addMonths(prev, 1))} aria-label="Następny miesiąc">
+                                ▶
+                            </button>
+                        </div>
+                    </div>
+
+                    <div className="calendar">
+                        <div className="calendar-weekdays">
+                            {['Pon', 'Wt', 'Śr', 'Czw', 'Pt', 'Sob', 'Nd'].map((day) => (
+                                <span key={day}>{day}</span>
+                            ))}
+                        </div>
+                        <div className="calendar-grid">
+                            {delegationsByDay.map(({ day, matches }) => {
+                                const isStart = Boolean(selectedRange.start && isSameDay(day, selectedRange.start));
+                                const isEnd = Boolean(selectedRange.end && isSameDay(day, selectedRange.end));
+                                const isInside = Boolean(
+                                    selectedRange.start &&
+                                        selectedRange.end &&
+                                        isWithinInterval(day, {
+                                            start: selectedRange.start,
+                                            end: selectedRange.end,
+                                        }),
+                                );
+                                const isOutsideMonth = !isSameMonth(day, currentMonth);
+                                const hasDelegation = matches.length > 0;
+
+                                return (
+                                    <button
+                                        key={day.toISOString()}
+                                        type="button"
+                                        className={`calendar-day ${isOutsideMonth ? 'muted' : ''} ${isInside ? 'selected' : ''} ${
+                                            isStart || isEnd ? 'range-edge' : ''
+                                        } ${hasDelegation ? 'has-delegation' : ''}`}
+                                        onClick={() => handleDaySelection(day)}
+                                        aria-pressed={isInside}
+                                        aria-label={`Dzień ${format(day, 'dd MMMM yyyy')}${hasDelegation ? ', posiada delegację' : ''}`}
+                                    >
+                                        <span className="day-number">{format(day, 'd')}</span>
+                                        {hasDelegation && <span className="dot" aria-hidden />}
+                                        {isStart && <span className="pill">Start</span>}
+                                        {isEnd && <span className="pill">Koniec</span>}
+                                    </button>
+                                );
+                            })}
+                        </div>
+                    </div>
+                </section>
+
+                <section className="planner-grid" id="delegacje">
+                    <div className="selection-card">
+                        <p className="eyebrow">Wybrany zakres</p>
+                        <h3>Tworzysz delegację</h3>
+                        <ul className="selection-meta">
+                            <li>
+                                <span>Od</span>
+                                <strong>{selectedRange.start ? format(selectedRange.start, 'dd.MM.yyyy') : '–'}</strong>
+                            </li>
+                            <li>
+                                <span>Do</span>
+                                <strong>{selectedRange.end ? format(selectedRange.end, 'dd.MM.yyyy') : '–'}</strong>
+                            </li>
+                            <li>
+                                <span>Dni delegacji</span>
+                                <strong>
+                                    {selectedRange.start && selectedRange.end
+                                        ? Math.max(
+                                              1,
+                                              Math.ceil(
+                                                  (selectedRange.end.getTime() - selectedRange.start.getTime()) / (1000 * 60 * 60 * 24),
+                                              ) + 1,
+                                          )
+                                        : '0'}
+                                </strong>
+                            </li>
+                        </ul>
+                        <p className="subtitle">
+                            Zmiany widoczne powyżej pojawią się po udanym zapisie w bazie. Aktualizacje pobieramy przez endpointy
+                            ASP.NET.
+                        </p>
+                    </div>
+
+                    <form className="delegation-form" onSubmit={handleSubmit}>
+                        <div className="form-header">
+                            <div>
+                                <p className="eyebrow">Szczegóły</p>
+                                <h3>Nowa delegacja</h3>
+                                <p className="subtitle">Uzupełnij wymagane pola zgodne z modelem backendu.</p>
+                            </div>
+                            <span className={`status-chip ${mutation.isPending ? 'pending' : 'ready'}`}>
+                                {mutation.isPending ? 'Wysyłanie…' : 'Gotowe do wysłania'}
+                            </span>
+                        </div>
+
+                        <div className="form-grid">
+                            <label>
+                                Imię pracownika
+                                <input
+                                    type="text"
+                                    name="pracownikImie"
+                                    value={formState.pracownikImie}
+                                    onChange={handleInputChange}
+                                    placeholder="np. Jan"
+                                    required
+                                />
+                            </label>
+                            <label>
+                                Nazwisko pracownika
+                                <input
+                                    type="text"
+                                    name="pracownikNazwisko"
+                                    value={formState.pracownikNazwisko}
+                                    onChange={handleInputChange}
+                                    placeholder="np. Kowalski"
+                                    required
+                                />
+                            </label>
+                            <label>
+                                ID pracownika
+                                <input
+                                    type="number"
+                                    name="pracownikID"
+                                    value={formState.pracownikID}
+                                    onChange={handleInputChange}
+                                    placeholder="np. 1024"
+                                    required
+                                />
+                            </label>
+                            <label>
+                                Miejsce delegacji
+                                <input
+                                    type="text"
+                                    name="miejsce"
+                                    value={formState.miejsce}
+                                    onChange={handleInputChange}
+                                    placeholder="Miasto lub region"
+                                    required
+                                />
+                            </label>
+                            <label className="full-width">
+                                Uwagi dla zespołu
+                                <textarea
+                                    name="uwagi"
+                                    value={formState.uwagi}
+                                    onChange={handleInputChange}
+                                    placeholder="Logistyka, nocleg, transport..."
+                                    rows={3}
+                                />
+                            </label>
+                        </div>
+
+                        <button className="primary" type="submit" disabled={mutation.isPending}>
+                            Zapisz delegację
+                        </button>
+                        {submitMessage && <p className="form-message">{submitMessage}</p>}
+                    </form>
+
+                    <div className="timeline" id="raporty">
+                        <div className="timeline-header">
+                            <div>
+                                <p className="eyebrow">Nadchodzące</p>
+                                <h3>Twoje delegacje</h3>
+                            </div>
+                        </div>
+                        <div className="timeline-list">
+                            {delegacje.length === 0 && <p className="subtitle">Brak zapisanych delegacji w bazie.</p>}
+                            {delegacje.map((delegacja) => (
+                                <article className="timeline-item" key={`${delegacja.partitionKey}-${delegacja.rowKey}`}>
+                                    <div>
+                                        <p className="eyebrow">{delegacja.miejsce}</p>
+                                        <h4>
+                                            {delegacja.pracownikImie} {delegacja.pracownikNazwisko}
+                                        </h4>
+                                        <p className="subtitle">
+                                            {format(new Date(delegacja.dataRozpoczecia), 'dd.MM.yyyy')} –{' '}
+                                            {format(new Date(delegacja.dataZakonczenia), 'dd.MM.yyyy')}
+                                        </p>
+                                    </div>
+                                    <div className="pill subtle">ID: {delegacja.pracownikID}</div>
+                                </article>
+                            ))}
+                        </div>
+                    </div>
+                </section>
+            </main>
+        </div>
     );
 };
 

--- a/projekt-delegacje/src/styles/Dashboard.css
+++ b/projekt-delegacje/src/styles/Dashboard.css
@@ -13,6 +13,11 @@ html {
   --banner-padding-max: 4rem;
   --gap-min: 1.6rem;
   --gap-max: 3rem;
+  --card: #0f172a;
+  --card-strong: #111827;
+  --border: #1f2937;
+  --muted: #6b7280;
+  --glow: rgba(59, 130, 246, 0.2);
 }
 
 .dark-header {
@@ -136,5 +141,382 @@ html {
 
   .menu-toggle {
     font-size: 1.3em;
+  }
+}
+
+/* —— Dashboard layout —— */
+.dashboard-wrapper {
+  background: radial-gradient(circle at 20% 20%, rgba(37, 99, 235, 0.15), transparent 25%),
+    radial-gradient(circle at 80% 0%, rgba(14, 165, 233, 0.12), transparent 20%),
+    #0b1223;
+  min-height: 100vh;
+  color: var(--white);
+}
+
+.dashboard-main {
+  padding: 140px 2rem 3rem;
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.hero-card {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.18), rgba(14, 165, 233, 0.08));
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+}
+
+.hero-card h1 {
+  margin: 0.3rem 0;
+  font-size: 2.2rem;
+}
+
+.hero-card .subtitle {
+  max-width: 540px;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 0.8rem;
+  margin-top: 1rem;
+  flex-wrap: wrap;
+}
+
+.hero-meta {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 1.2rem 1.6rem;
+  min-width: 220px;
+  text-align: right;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+}
+
+.metric-label {
+  color: var(--muted);
+  margin: 0;
+  font-size: 0.85rem;
+}
+
+.metric-value {
+  margin: 0.2rem 0;
+  font-size: 2.8rem;
+  font-weight: 700;
+}
+
+.metric-caption {
+  color: var(--muted);
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.8rem;
+  color: var(--muted);
+  margin: 0;
+}
+
+.subtitle {
+  color: var(--muted);
+  margin: 0.4rem 0 0;
+  line-height: 1.5;
+}
+
+.primary {
+  background: linear-gradient(120deg, #2563eb, #1e3a8a);
+  color: white;
+  border: none;
+  padding: 0.8rem 1.3rem;
+  border-radius: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 0 10px 30px rgba(37, 99, 235, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primary:active {
+  transform: translateY(1px);
+  box-shadow: 0 6px 20px rgba(37, 99, 235, 0.2);
+}
+
+.ghost {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--white);
+  padding: 0.8rem 1.3rem;
+  border-radius: 12px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.calendar-section,
+.planner-grid {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 1.5rem;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.25);
+}
+
+.calendar-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.month-nav {
+  display: flex;
+  gap: 0.6rem;
+}
+
+.month-nav button {
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--white);
+  cursor: pointer;
+}
+
+.calendar {
+  margin-top: 1rem;
+}
+
+.calendar-weekdays {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  color: var(--muted);
+  text-align: center;
+  font-size: 0.9rem;
+  margin-bottom: 0.5rem;
+}
+
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.calendar-day {
+  position: relative;
+  padding: 0.8rem;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background: var(--card-strong);
+  min-height: 72px;
+  color: white;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.1s ease;
+}
+
+.calendar-day:hover {
+  border-color: rgba(59, 130, 246, 0.6);
+  box-shadow: 0 8px 30px rgba(37, 99, 235, 0.25);
+  transform: translateY(-2px);
+}
+
+.calendar-day .day-number {
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+.calendar-day .dot {
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #34d399;
+  bottom: 10px;
+  left: 10px;
+  box-shadow: 0 0 0 8px rgba(52, 211, 153, 0.12);
+}
+
+.calendar-day.muted {
+  color: var(--muted);
+  opacity: 0.6;
+}
+
+.calendar-day.selected {
+  border-color: rgba(37, 99, 235, 0.8);
+  box-shadow: 0 8px 40px var(--glow);
+  background: linear-gradient(160deg, rgba(37, 99, 235, 0.18), rgba(14, 165, 233, 0.08));
+}
+
+.calendar-day.range-edge {
+  outline: 2px solid rgba(37, 99, 235, 0.8);
+}
+
+.calendar-day.has-delegation::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 14px;
+  border: 1px dashed rgba(52, 211, 153, 0.4);
+  pointer-events: none;
+}
+
+.calendar-day .pill {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: rgba(255, 255, 255, 0.08);
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  border: 1px solid var(--border);
+}
+
+.planner-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 1rem;
+}
+
+.selection-card,
+.delegation-form,
+.timeline {
+  background: var(--card-strong);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 1.2rem 1.3rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+
+.selection-meta {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.8rem;
+}
+
+.selection-meta li {
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 12px;
+  padding: 0.8rem;
+  border: 1px solid var(--border);
+}
+
+.selection-meta span {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.selection-meta strong {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 1.2rem;
+}
+
+.delegation-form .form-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.status-chip {
+  padding: 0.4rem 0.8rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  font-weight: 700;
+  color: var(--muted);
+}
+
+.status-chip.pending {
+  border-color: rgba(37, 99, 235, 0.6);
+  color: white;
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.12);
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+  margin: 1rem 0;
+}
+
+.delegation-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.delegation-form input,
+.delegation-form textarea {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 0.75rem 0.9rem;
+  color: white;
+  font-size: 1rem;
+}
+
+.full-width {
+  grid-column: 1 / -1;
+}
+
+.form-message {
+  margin-top: 0.6rem;
+  color: #34d399;
+}
+
+.timeline-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  margin-top: 0.8rem;
+}
+
+.timeline-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.8rem 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.pill.subtle {
+  background: rgba(255, 255, 255, 0.06);
+  padding: 0.3rem 0.8rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  color: var(--muted);
+}
+
+@media (max-width: 768px) {
+  .hero-card,
+  .calendar-section,
+  .planner-grid {
+    padding: 1.2rem;
+  }
+
+  .dashboard-main {
+    padding-top: 120px;
+  }
+
+  .timeline-item {
+    flex-direction: column;
+    align-items: flex-start;
   }
 }


### PR DESCRIPTION
## Summary
- add interactive calendar experience on dashboard for selecting delegation date ranges
- connect dashboard form to backend create endpoint and refresh delegations via React Query
- update dashboard styles with modern supershift-inspired layout and timeline

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d9d0d93e8832b83504329f0d0436d)